### PR TITLE
revert commit 17b01430db7 cause Google now use golang.org/x as prefered ...

### DIFF
--- a/cmd/gopass/main.go
+++ b/cmd/gopass/main.go
@@ -26,10 +26,10 @@ import (
 	"strconv"
 	"strings"
 
-	"code.google.com/p/go.crypto/ssh/terminal"
 	"github.com/ReAzem/gopass"
 	"github.com/ReAzem/gopass/pwgen"
 	"github.com/mgutz/ansi"
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 var (


### PR DESCRIPTION
...repos

for officials modules
